### PR TITLE
remove unnecessary parenthesis in example app

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -37,7 +37,7 @@ export default class App extends React.PureComponent {
           buttonNegative: "Cancel"
         }
       }
-    })).then(granted => {
+    }).then(granted => {
       if (granted) {
         this._startUpdatingLocation();
       }


### PR DESCRIPTION
There was a parenthesis causing an error on line 40.